### PR TITLE
Fix for constructor call in main.dart

### DIFF
--- a/google-maps-in-flutter/step_4/lib/main.dart
+++ b/google-maps-in-flutter/step_4/lib/main.dart
@@ -20,7 +20,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatefulWidget {
-  const MyApp({super.key});
+  const MyApp({key}) : super(key: key);
 
   @override
   State<MyApp> createState() => _MyAppState();


### PR DESCRIPTION
This fixed the compiler errors for me so that I was able to run the google_maps_in_flutter sample code (dart 2.15.1 and flutter 2.8.1-stable) related to "Add use_super_parameters lint #861"

## Pre-launch Checklist

- [x] I read the [Effective Dart: Style] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-devrel channel on [Discord].

<!-- Links -->
[Effective Dart: Style]: https://dart.dev/guides/language/effective-dart/style
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
